### PR TITLE
Export task store stats as gauge.

### DIFF
--- a/vars.go
+++ b/vars.go
@@ -329,7 +329,7 @@ func taskStoreMetric(name string, value float64) (metric prometheus.Metric) {
 				"Task store state.",
 				stateLabel, nil,
 			),
-			prometheus.CounterValue,
+			prometheus.GaugeValue,
 			value, state,
 		)
 	}


### PR DESCRIPTION
The exported value encodes the total number of jobs in this state. The value can increase and decrease for each state and thefore needs to be exported as a gauge.

See https://github.com/apache/aurora/blob/master/src/main/java/org/apache/aurora/scheduler/TaskVars.java#L186
