### PR TITLE
Add tasks_pending per job metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION  := 0.1.0
+VERSION  := 0.2.0
 TARGET   := aurora_exporter
 
 include Makefile.COMMON

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -48,7 +48,7 @@ ifeq ($(GOOS),darwin)
 	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)
 endif
 
-GO_VERSION ?= 1.4.2
+GO_VERSION ?= 1.5.2
 
 ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
 	GOROOT := $(shell go env GOROOT)


### PR DESCRIPTION
Makes it easy for a job owner to track if a job is in trouble.
