### PR TITLE
Change `prometheus.Counter.Set` to be `prometheus.Counter.Add`

### DIFF
--- a/vars.go
+++ b/vars.go
@@ -500,7 +500,7 @@ func (p *parser) parse(name string, value float64, ch chan<- prometheus.Metric) 
 		switch m := p.metric.(type) {
 		case *prometheus.CounterVec:
 			metric = m.WithLabelValues(match[1:]...)
-			metric.(prometheus.Counter).Set(value)
+			metric.(prometheus.Counter).Add(value)
 		case *prometheus.GaugeVec:
 			metric = m.WithLabelValues(match[1:]...)
 			metric.(prometheus.Gauge).Set(value)


### PR DESCRIPTION
https://github.com/prometheus/client_golang/commit/2fee50beaa152342e8347c41edf2202c3bd5f858#diff-4eafde073feb6e8d8a2aefcc731b59c4
introduces a bug in the code where

```
$ make
...
../go/src/github.com/tommyulfsparre/aurora_exporter/.build/go1.7.1/bin/go
build  -o aurora_exporter
./vars.go:503: metric.(prometheus.Counter).Set undefined (type
prometheus.Counter has no field or method Set)
make: *** [aurora_exporter] Error 2

```
the `Set` method was removed for `prometheus.Counter` PR forth coming to
address.