### PR TITLE
Add support for znode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Name                            | Description
 web.listen-address              | Address to listen on for web interface and telemetry.
 web.telemetry-path              | Path under which to expose metrics.
 exporter.aurora-url             | [URL](#aurora-url) to an Aurora scheduler or ZooKeeper ensemble.
+zk.path                         | The path for the aurora scheduler znode, this defaults to `/aurora/scheduler`
 exporter.bypass-leader-redirect | Don't follow redirects to the leader instance.
 
 #### Aurora URL

--- a/finder.go
+++ b/finder.go
@@ -14,15 +14,14 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 )
 
-const (
-	zkLeaderPrefix = "singleton_candidate_"
-)
+const zkLeaderPrefix = "singleton_candidate_"
+
 
 type finder interface {
 	leaderURL() (string, error)
 }
 
-func newFinder(url string, znode string) (f finder, err error) {
+func newFinder(url, znode string) (f finder, err error) {
 	if strings.HasPrefix(url, "http") {
 		f = &httpFinder{url: url}
 	}
@@ -85,7 +84,7 @@ type zkFinder struct {
 	leaderIP string
 }
 
-func newZkFinder(url string, znode string) *zkFinder {
+func newZkFinder(url, znode string) *zkFinder {
 	zkSrvs, err := hostsFromURL(url)
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	addr           = flag.String("web.listen-address", ":9113", "Address to listen on for web interface and telemetry.")
 	auroraURL      = flag.String("exporter.aurora-url", "http://127.0.0.1:8081", "URL to an Aurora scheduler or ZooKeeper ensemble")
 	metricPath     = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	zkPath     = flag.String("zk.path", "/aurora/scheduler", "zkNode that aurora matains master election.")
+	zkPath     = flag.String("zk.path", "/aurora/scheduler", "zkNode that aurora maintains master election.")
 	bypassRedirect = flag.Bool("exporter.bypass-leader-redirect", false,
 		"When scraping a HTTP scheduler url, don't follow redirects to the leader instance.")
 )

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	addr           = flag.String("web.listen-address", ":9113", "Address to listen on for web interface and telemetry.")
 	auroraURL      = flag.String("exporter.aurora-url", "http://127.0.0.1:8081", "URL to an Aurora scheduler or ZooKeeper ensemble")
 	metricPath     = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	zkPath     = flag.String("zk.path", "/aurora/scheduler", "zkNode that aurora matains master election.")
 	bypassRedirect = flag.Bool("exporter.bypass-leader-redirect", false,
 		"When scraping a HTTP scheduler url, don't follow redirects to the leader instance.")
 )
@@ -220,7 +221,7 @@ func newRequest(method, urlStr string, body io.Reader, bypass bool) (*http.Reque
 func main() {
 	flag.Parse()
 
-	finder, err := newFinder(*auroraURL)
+	finder, err := newFinder(*auroraURL, *zkPath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This allows for the aurora scheduler znode to be passed as
a flag at runtime. We rely on zk for multiple clusters and to enable this to work for us
it become necessary to allow us to direct the scraper to the correct znode. Let me know
your feedback on the pr looking forward to hearing back.