### PR TITLE
Do not ignore the redirect to the leading master for quotas scraping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ web.listen-address              | Address to listen on for web interface and tel
 web.telemetry-path              | Path under which to expose metrics.
 exporter.aurora-url             | [URL](#aurora-url) to an Aurora scheduler or ZooKeeper ensemble.
 zk.path                         | The path for the aurora scheduler znode, this defaults to `/aurora/scheduler`
-exporter.bypass-leader-redirect | Don't follow redirects to the leader instance.
+exporter.bypass-leader-redirect | Don't follow redirects to the leader instance. Ignored for quotas scraping because it results in an internal server error on non-leading masters.
 
 #### Aurora URL
 Can be either a single ``http://host:port`` or a comma-separated ``zk://host1:port,zk://host2:port`` URL.

--- a/main.go
+++ b/main.go
@@ -99,8 +99,8 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.duration
 }
 
-func (e *exporter) parseQuotas(url string, bypass bool, ch chan<- prometheus.Metric) error {
-	req, err := newRequest("GET", url+"/quotas", nil, bypass)
+func (e *exporter) parseQuotas(url string, ch chan<- prometheus.Metric) error {
+	req, err := newRequest("GET", url+"/quotas", nil, false)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (e *exporter) scrape(ch chan<- prometheus.Metric) {
 		recordErr(err)
 	}
 
-	if err = e.parseQuotas(url, *bypassRedirect, ch); err != nil {
+	if err = e.parseQuotas(url, ch); err != nil {
 		recordErr(err)
 	}
 }


### PR DESCRIPTION
This PR is one way to fix #22.

So the problem is that the non-leading aurora masters do not have access to storage, in which the quotas are stored, and only the leading master can do that.
This is a design limitation and not easily fixed on the aurora side.
So we have the following options in aurora_exporter:
1) ignore the config option bypassRedirect for quotas parsing (implemented in the PR)
2) check whether we are pulling metrics from the leading master, and not request quotas if not
3) pull quotas from aurora anyways, but check for error code 500

Option 3 is suboptimal, as it clutters the aurora log every time we query non-leading masters, which greatly hinders debugging, because all these exceptions are logged in the aurora log with the full stacktrace.

Option 2 is hard to implement correctly, as we would have to precisely determine the master, which in case of fail-overs is not always correct.

Option 1 ignores the users wishes and provides the same quotas metrics from every aurora_exporter instance (if you assume one aurora_exporter per aurora master).

Still, it is the least worse option, so I implemented it here in the PR.
If you agree with this assessment, it would be great if we could have a new release for this patch, so we can deploy this to our systems.
