### PR TITLE
Handler is now in the promhttp package

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const namespace = "aurora"
@@ -273,7 +274,7 @@ func main() {
 	exporter := newAuroraExporter(finder)
 	prometheus.MustRegister(exporter)
 
-	http.Handle(*metricPath, prometheus.Handler())
+	http.Handle(*metricPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, *metricPath, http.StatusMovedPermanently)
 	})


### PR DESCRIPTION
Error when using newer versions of the prometheus package:
```
github.com/tommyulfsparre/aurora_exporter/main.go:276:27: undefined: prometheus.Handler
```